### PR TITLE
Find hosts between nested slashes

### DIFF
--- a/find-vault-oldhosts
+++ b/find-vault-oldhosts
@@ -41,7 +41,7 @@ def main():
     # between // as a path separator, with three or more period-separated
     # pieces.  We cache the first lookup for any host in a dict.
     for secret in secrets:
-        match = re.search('/(([^.]+\.){2,}[^.]+)/', secret)
+        match = re.search('/(([^\/.]+\.){2,}[^.]+)/', secret)
         if match:
             hostname = match.group(1)
             if hostname in host_lookup:


### PR DESCRIPTION
I used this to clean up a few old secrets, and then found that the regex included some hosts that were active.

Compare 

`puppet/xsearch-stage.stanford.edu/ssl-csr`

where the regex parsed out the host as `xsearch-stage.stanford.edu`

with

`puppet/common/ssl/swp/bv.stanford.edu/ssl-cert`

where the regex parsed out the host as `common/ssl/swp/bv.stanford.edu`

which wouldn't pass the aliveness test, where `bv.stanford.edu` is alive.

The updated regex in this PR produces the same output, but excludes the following values:
```
puppet/common/ssl/swp/bv.stanford.edu/ssl-cert
puppet/common/ssl/swp/bv.stanford.edu/ssl-key
puppet/common/swp/myorcid.stanford.edu/vhost-cert
puppet/common/swp/myorcid.stanford.edu/vhost-key
puppet/common/swp/revslib.stanford.edu/vhost-cert
puppet/common/swp/revslib.stanford.edu/vhost-key
puppet/common/swp/sulredirect-test-a.stanford.edu/ssl-cert
puppet/common/swp/sulredirect-test-a.stanford.edu/ssl-key
puppet/common/swp/sulredirect-test-b.stanford.edu/ssl-cert
puppet/common/swp/sulredirect-test-b.stanford.edu/ssl-key
puppet/common/swp/sulredirect-test-c.stanford.edu/ssl-cert
puppet/common/swp/sulredirect-test-c.stanford.edu/ssl-key
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-cert
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-csr
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-csr-pending
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-id-pending
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-key
puppet/common/swp/sulredirect-test-d.stanford.edu/ssl-key-pending
secret/ssl-cert/argo-qa.stanford.edu/shibboleth
secret/ssl-cert/sul-preassembly-qa.stanford.edu/shibboleth
secret/ssl-key/argo-qa.stanford.edu/shibboleth
secret/ssl-key/sul-preassembly-qa.stanford.edu/shibboleth
``` 

and the hosts in those values all show up in netdb.